### PR TITLE
Switch from aioredis to redis

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import asyncio
 import json
 
-import aioredis
+from redis import asyncio as aioredis
 import sentry_sdk
 from fastapi import FastAPI
 from jinja2 import Environment, FileSystemLoader

--- a/api/models.py
+++ b/api/models.py
@@ -5,7 +5,7 @@ import random
 from datetime import datetime
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
-import aioredis
+from redis import asyncio as aioredis
 
 if TYPE_CHECKING:
     from typing_extensions import Self

--- a/api/utils.py
+++ b/api/utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-import aioredis
+from redis import asyncio as aioredis
 import sentry_sdk
 
 

--- a/fetch/main.py
+++ b/fetch/main.py
@@ -19,7 +19,7 @@ import os.path
 from datetime import datetime, timezone
 
 import aiohttp
-import aioredis
+from redis import asyncio as aioredis
 import sentry_sdk
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ rapidfuzz==2.8.0
 Jinja2==3.1.2
 psutil==5.9.2
 sentry-sdk==1.24.0
-aioredis
+redis
 typing_extensions==4.2.0


### PR DESCRIPTION
aioredis is now deprecated and merged into the official redis-py library.

Following the recommendation here:
  - https://github.com/aio-libs-abandoned/aioredis-py/blob/19be499015a8cf32580e937cbfd711fd48489eca/README.md We can make a simple switch.

This also fixes compatibility with Python 3.11, as aioredis has had an issue on this version before it was abandoned.