### PR TITLE
requirements: pin redis to 5.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ rapidfuzz==3.9.4
 Jinja2==3.1.4
 psutil==5.9.2
 sentry-sdk==2.10.0
-redis
+redis==5.0.1
 typing_extensions==4.12.2


### PR DESCRIPTION
When not running in Docker, this error happens:
```
Exception ignored in: <function AbstractConnection.__del__ at 0xfce535d495a0>
Traceback (most recent call last):
  File "/opt/UDB-API/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 216, in __del__
    self._close()
  File "/opt/UDB-API/venv/lib/python3.10/site-packages/redis/asyncio/connection.py", line 223, in _close
    self._writer.close()
  File "/usr/lib/python3.10/asyncio/streams.py", line 337, in close
    return self._transport.close()
  File "/usr/lib/python3.10/asyncio/selector_events.py", line 706, in close
    self._loop.call_soon(self._call_connection_lost, None)
  File "/usr/lib/python3.10/asyncio/base_events.py", line 753, in call_soon
    self._check_closed()
  File "/usr/lib/python3.10/asyncio/base_events.py", line 515, in _check_closed
    raise RuntimeError('Event loop is closed')
```
... and causes shell scripts to die.

It seems to be an upstream Redis issue [0].

On Python 3.10 and 3.12, it has been verified that 5.0.1 still works. Thus, stick to that until a solution is found.

[0]: https://github.com/redis/redis-py/issues/2891